### PR TITLE
for externalizing jwt secret key to config-repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.idea/vcs.xml

--- a/auth-service/src/main/java/com/micro/authservice/service/JWTService.java
+++ b/auth-service/src/main/java/com/micro/authservice/service/JWTService.java
@@ -3,27 +3,39 @@ package com.micro.authservice.service;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.security.Key;
 import java.util.Date;
 import java.util.List;
 
 @Service
 public class JWTService {
 
+    @Value("${jwt.secret}")
+    private String jwtSecret; // ✅ Inject from config server
     // ✅ Use a static, shared secret key (same as in gateway-service)
-    private final SecretKey secretKey = Keys.hmacShaKeyFor("my-very-secret-key-1234567890123456".getBytes());
+    private Key secretKey;
 
     private final long expirationMillis = 60 * 60 * 1000;
 
+    // ✅ Initialize secret key after the property is loaded
+    @PostConstruct
+    public void init() {
+        this.secretKey = Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    // ✅ Generate token using shared secret key
     public String generateToken(String email, List<String> roles) {
         return Jwts.builder()
                 .setSubject(email)
                 .claim("roles", roles)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMillis))
-                .signWith(secretKey)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 }

--- a/gateway-service/src/main/java/com/micro/gateway_service/config/JwtConfig.java
+++ b/gateway-service/src/main/java/com/micro/gateway_service/config/JwtConfig.java
@@ -1,6 +1,7 @@
 package com.micro.gateway_service.config;
 
 import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -9,10 +10,14 @@ import javax.crypto.SecretKey;
 @Configuration
 public class JwtConfig {
 
+    // ✅ Inject secret key from application.yml (resolved from config server)
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
     @Bean
     public SecretKey jwtSecretKey() {
         // ✅ Define and return the secret key used for signing and verifying JWT tokens
         // Note: This secret must exactly match the one used in auth-service
-        return Keys.hmacShaKeyFor("my-very-secret-key-1234567890123456".getBytes());
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
     }
 }


### PR DESCRIPTION
Added shared secret key to the config repository (e.g., in gateway-service.yml and auth-service.yml)
------------------------------------------------------------------------------------
 In both gateway-service.yml and auth-service.yml (in GitHub config repo), add:
 jwt: secret: my-very-secret-key-1234567890123456